### PR TITLE
Agregar convertidores de fecha.

### DIFF
--- a/v3_3/pom.xml
+++ b/v3_3/pom.xml
@@ -12,12 +12,25 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <dependencies>
+        <dependency>
+            <groupId>com.migesok</groupId>
+            <artifactId>jaxb-java-time-adapters</artifactId>
+            <version>1.1.3</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>jaxb2-maven-plugin</artifactId>
                 <version>2.5.0</version>
+                <configuration>
+                    <addGeneratedAnnotation>true</addGeneratedAnnotation>
+                    <target>2.1</target>
+                    <verbose>true</verbose>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/v3_3/src/main/xjb/global.xjb
+++ b/v3_3/src/main/xjb/global.xjb
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<bindings xmlns="http://java.sun.com/xml/ns/jaxb" version="2.1"
+          xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc">
+
+    <globalBindings>
+        <xjc:javaType name="java.time.LocalDateTime" xmlType="xs:dateTime"
+                      adapter="com.migesok.jaxb.adapter.javatime.LocalDateTimeXmlAdapter"/>
+    </globalBindings>
+
+</bindings>


### PR DESCRIPTION
Agregar convertidores de fecha en la configuración de XJC para evitar utilizar XMLGregorianCalendar y utilizar objetos de fecha de Java 8 en vez.