### PR TITLE
Eliminar advertencias durante generación de código

### DIFF
--- a/v3_3/pom.xml
+++ b/v3_3/pom.xml
@@ -28,8 +28,8 @@
                 <version>2.5.0</version>
                 <configuration>
                     <addGeneratedAnnotation>true</addGeneratedAnnotation>
+                    <locale>es</locale>
                     <target>2.1</target>
-                    <verbose>true</verbose>
                 </configuration>
                 <executions>
                     <execution>

--- a/v3_3/src/main/xjb/catálogos.xjb
+++ b/v3_3/src/main/xjb/catálogos.xjb
@@ -7,6 +7,27 @@
         <schemaBindings>
             <package name="mx.gob.sat.cfd.catálogos" />
         </schemaBindings>
+
+        <bindings node="/xs:schema/xs:simpleType[@name='c_CodigoPostal']">
+            <typesafeEnumClass map="false" />
+        </bindings>
+
+        <bindings node="/xs:schema/xs:simpleType[@name='c_ClaveProdServ']">
+            <typesafeEnumClass map="false" />
+        </bindings>
+
+        <bindings node="/xs:schema/xs:simpleType[@name='c_ClaveUnidad']">
+            <typesafeEnumClass map="false" />
+        </bindings>
+
+        <bindings node="/xs:schema/xs:simpleType[@name='c_Colonia']">
+            <typesafeEnumClass map="false" />
+        </bindings>
+
+        <bindings node="/xs:schema/xs:simpleType[@name='c_Municipio']">
+            <typesafeEnumClass map="false" />
+        </bindings>
+
     </bindings>
 
 </bindings>

--- a/v3_3/src/main/xjb/catálogos.xjb
+++ b/v3_3/src/main/xjb/catálogos.xjb
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<bindings xmlns="http://java.sun.com/xml/ns/jaxb" version="2.1"
+          xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc">
+
+    <bindings schemaLocation="../xsd/catCFDI.xsd">
+        <schemaBindings>
+            <package name="mx.gob.sat.cfd.catálogos" />
+        </schemaBindings>
+    </bindings>
+
+</bindings>

--- a/v3_3/src/main/xjb/comprobantes.xjb
+++ b/v3_3/src/main/xjb/comprobantes.xjb
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<bindings xmlns="http://java.sun.com/xml/ns/jaxb" version="2.1"
+          xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc">
+
+    <bindings schemaLocation="../xsd/cfdi33.xsd">
+        <schemaBindings>
+            <package name="mx.gob.sat.cfd.v3_3" />
+        </schemaBindings>
+    </bindings>
+
+</bindings>

--- a/v3_3/src/main/xjb/global.xjb
+++ b/v3_3/src/main/xjb/global.xjb
@@ -3,7 +3,7 @@
           xmlns:xs="http://www.w3.org/2001/XMLSchema"
           xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc">
 
-    <globalBindings>
+    <globalBindings enableJavaNamingConventions="true">
         <xjc:javaType name="java.time.LocalDateTime" xmlType="xs:dateTime"
                       adapter="com.migesok.jaxb.adapter.javatime.LocalDateTimeXmlAdapter"/>
     </globalBindings>


### PR DESCRIPTION
Eliminar advertencias durante la generación de código.

Los siguientes elementos de catálogos no se generarán debido a su tamaño:

- Código postal.
- Clave de producto.
- Clave de unidad.
- Colonia.
- Municipio.

También se agregaron los nombres de paquetes para catálogos y para comprobante v3.3.