### PR TITLE
Soporte para timbre fiscal v1.0

### DIFF
--- a/tfd/v1_0/pom.xml
+++ b/tfd/v1_0/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>tfd-v1_0</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>Percont CFDI - Timbre Fiscal Digital v1.0</name>
+
+    <parent>
+        <artifactId>cfdi-parent</artifactId>
+        <groupId>io.github.percontmx.cfdi</groupId>
+        <version>1.0.1</version>
+        <relativePath>../../cfdi-parent/pom.xml</relativePath>
+    </parent>
+
+    <build>
+        <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+                <source>1.8</source>
+                <target>1.8</target>
+            </configuration>
+        </plugin>
+
+        <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>jaxb2-maven-plugin</artifactId>
+            <configuration>
+                <addGeneratedAnnotation>true</addGeneratedAnnotation>
+                <locale>es</locale>
+                <target>2.1</target>
+            </configuration>
+            <executions>
+                <execution>
+                    <goals>
+                        <goal>xjc</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/tfd/v1_0/src/main/xjb/bindings.xjb
+++ b/tfd/v1_0/src/main/xjb/bindings.xjb
@@ -1,12 +1,28 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<bindings xmlns="http://java.sun.com/xml/ns/jaxb" version="2.1">
+<bindings xmlns="http://java.sun.com/xml/ns/jaxb" version="2.1"
+          xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
-    <globalBindings localScoping="toplevel" />
+    <globalBindings localScoping="toplevel"
+                    fixedAttributeAsConstantProperty="true"
+                    optionalProperty="isSet" />
 
     <bindings schemaLocation="../xsd/TimbreFiscalDigital.xsd">
         <schemaBindings>
             <package name="mx.gob.sat.tfd.v1_0" />
         </schemaBindings>
+
+        <bindings node="//xs:attribute[@name='noCertificadoSAT']">
+            <property name="númeroDeCertificado" />
+        </bindings>
+
+        <bindings node="//xs:attribute[@name='selloCFD']">
+            <property name="selloDelComprobante" />
+        </bindings>
+
+        <bindings node="//xs:attribute[@name='selloSAT']">
+            <property name="selloDelSAT" />
+        </bindings>
+
     </bindings>
 
 </bindings>

--- a/tfd/v1_0/src/main/xjb/bindings.xjb
+++ b/tfd/v1_0/src/main/xjb/bindings.xjb
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<bindings xmlns="http://java.sun.com/xml/ns/jaxb" version="2.1">
+
+    <globalBindings localScoping="toplevel" />
+
+    <bindings schemaLocation="../xsd/TimbreFiscalDigital.xsd">
+        <schemaBindings>
+            <package name="mx.gob.sat.tfd.v1_0" />
+        </schemaBindings>
+    </bindings>
+
+</bindings>

--- a/tfd/v1_0/src/main/xsd/TimbreFiscalDigital.xsd
+++ b/tfd/v1_0/src/main/xsd/TimbreFiscalDigital.xsd
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tfd="http://www.sat.gob.mx/TimbreFiscalDigital" targetNamespace="http://www.sat.gob.mx/TimbreFiscalDigital" elementFormDefault="qualified" attributeFormDefault="unqualified">
+    <xs:element name="TimbreFiscalDigital">
+        <xs:annotation>
+            <xs:documentation>Complemento requerido para el Timbrado Fiscal Digital que da valides a un Comprobante Fiscal Digital.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:attribute name="version" use="required" fixed="1.0">
+                <xs:annotation>
+                    <xs:documentation>Atributo requerido para la expresión de la versión del estándar del Timbre Fiscal Digital</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="UUID" use="required" id="UUID">
+                <xs:annotation>
+                    <xs:documentation>Atributo requerido para expresar los 36 caracteres del UUID de la transacción de timbrado</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:whiteSpace value="collapse"/>
+                        <xs:length value="36"/>
+                        <xs:pattern value="[a-f0-9A-F]{8}-[a-f0-9A-F]{4}-[a-f0-9A-F]{4}-[a-f0-9A-F]{4}-[a-f0-9A-F]{12}"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="FechaTimbrado" use="required">
+                <xs:annotation>
+                    <xs:documentation>Atributo requerido para expresar la fecha y hora de la generación del timbre </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:dateTime">
+                        <xs:whiteSpace value="collapse"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="selloCFD" use="required">
+                <xs:annotation>
+                    <xs:documentation>Atributo requerido para contener el sello digital del comprobante fiscal, que será timbrado. El sello deberá ser expresado cómo una cadena de texto en formato Base 64.</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:whiteSpace value="collapse"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="noCertificadoSAT" use="required">
+                <xs:annotation>
+                    <xs:documentation>Atributo requerido para expresar el número de serie del certificado del SAT usado para el Timbre</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:whiteSpace value="collapse"/>
+                        <xs:length value="20"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="selloSAT" use="required">
+                <xs:annotation>
+                    <xs:documentation>Atributo requerido para contener el sello digital del Timbre Fiscal Digital, al que hacen referencia las reglas de resolución miscelánea aplicable. El sello deberá ser expresado cómo una cadena de texto en formato Base 64.</xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:string">
+                        <xs:whiteSpace value="collapse"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/utils/jaxb-adapters/pom.xml
+++ b/utils/jaxb-adapters/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>jaxb-adapters</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>Percont CFDI - Adaptadores de JAXB</name>
+
+    <parent>
+        <artifactId>cfdi-parent</artifactId>
+        <groupId>io.github.percontmx.cfdi</groupId>
+        <version>1.0.1</version>
+        <relativePath>../../cfdi-parent/pom.xml</relativePath>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.migesok</groupId>
+            <artifactId>jaxb-java-time-adapters</artifactId>
+            <version>1.1.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/utils/jaxb-adapters/src/main/java/io/github/percontmx/cfdi/utils/jaxb/adapters/UUIDXMLAdapter.java
+++ b/utils/jaxb-adapters/src/main/java/io/github/percontmx/cfdi/utils/jaxb/adapters/UUIDXMLAdapter.java
@@ -1,4 +1,4 @@
-package mx.gob.sat.cfd.v3_3.adapters;
+package io.github.percontmx.cfdi.utils.jaxb.adapters;
 
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 import java.util.UUID;

--- a/utils/jaxb-adapters/src/test/java/io/github/percontmx/cfdi/utils/jaxb/adapters/UUIDXMLAdapterTest.java
+++ b/utils/jaxb-adapters/src/test/java/io/github/percontmx/cfdi/utils/jaxb/adapters/UUIDXMLAdapterTest.java
@@ -1,4 +1,4 @@
-package mx.gob.sat.cfd.v3_3.adapters;
+package io.github.percontmx.cfdi.utils.jaxb.adapters;
 
 import org.junit.Test;
 

--- a/v3_3/pom.xml
+++ b/v3_3/pom.xml
@@ -14,16 +14,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.migesok</groupId>
-            <artifactId>jaxb-java-time-adapters</artifactId>
-            <version>1.1.3</version>
-        </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13</version>
-            <scope>test</scope>
+            <groupId>io.github.percontmx.cfdi</groupId>
+            <artifactId>jaxb-adapters</artifactId>
+            <version>1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/v3_3/src/main/xjb/comprobantes.xjb
+++ b/v3_3/src/main/xjb/comprobantes.xjb
@@ -42,7 +42,7 @@
             <property>
                 <baseType>
                     <xjc:javaType name="java.util.UUID"
-                                  adapter="mx.gob.sat.cfd.v3_3.adapters.UUIDXMLAdapter" />
+                                  adapter="io.github.percontmx.cfdi.utils.jaxb.adapters.UUIDXMLAdapter" />
                 </baseType>
             </property>
         </bindings>


### PR DESCRIPTION
Soporte retroactivo de timbre fiscal v1.0.

También se creó un nuevo proyecto llamado JAXB-Adapters para juntar todos los adaptadores de JAXB.

closes #26 