### PR TITLE
Cambiar el tipo de dato destino del campo Días pagados

### DIFF
--- a/complementos/nomina-v12/src/main/xjb/general.xjb
+++ b/complementos/nomina-v12/src/main/xjb/general.xjb
@@ -18,7 +18,7 @@
             <bindings node="//xs:attribute[@name='NumDiasPagados']">
                 <property name="diasPagados">
                     <baseType>
-                        <xjc:javaType name="double"
+                        <xjc:javaType name="java.lang.Double"
                                       adapter="io.github.percontmx.cfdi.utils.jaxb.adapters.DoubleXMLAdapter" />
                     </baseType>
                 </property>


### PR DESCRIPTION
Actualizar el tipo de dato de `double` a `java.lang.Double` para el campo `DíasPagados` del complemento de nómina v1.2.

closes #114